### PR TITLE
Configuration and Docker overhaul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 
 .vscode
 
+
+# Ignore completion assists
+*.rope*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,15 @@
 FROM python:2.7
 MAINTAINER celliott
 
-# install unix dependencies
-RUN apt-get update && \
-  apt-get autoremove -y && \
-  apt-get install -y \
-    supervisor \
-    python-pip
-
 # install python dependencies
 ADD ./requirements.txt /requirements.txt
 RUN pip install -r /requirements.txt
 
-# add supervisor config
-ADD ./config/supervisor/* /etc/supervisor/conf.d/
+# add json config
+ADD ./config/sample.json /etc/weather_exporter/config.json
 
 # add weather_exporter script
 ADD ./src/weather_exporter /opt/weather_exporter
 RUN chmod +x /opt/weather_exporter/*
 
-# run supervisor
-CMD ["/usr/bin/supervisord", "-n"]
+ENTRYPOINT ["/opt/weather_exporter/exporter.py", "--config=/etc/weather_exporter/config.json"]

--- a/README.md
+++ b/README.md
@@ -7,6 +7,23 @@ A docker container for running a prometheus weather_exporter using Dark Sky API.
 
 ## Usage
 
+### Configuration
+
+`weather_exporter` can be configured via json file, environment, and/or commandline.
+Configuration option names are the same across all methods. Environment variables _MUST BE CAPITALIZED_.
+
+#### Configuration Options
+
+ - `config`: path to a json config file.
+ - `dark_sky_api_key`: API key to query with. _REQUIRED_.
+ - `dark_sky_api_uri`: URL of the darksky.net api (version as of 10/10/2017). Defaults to `https://api.darksky.net/forecast`.
+ - `scrape_interval`: how often to poll darksky.net for data in seconds. Defaults to `600` seconds.
+ - `endpoint_port`: what port to expose `weather_exporter` on. Defaults to `9265`.
+ - `cities`: comma-separated list of cities as understood by [`Nominatim`](https://wiki.openstreetmap.org/wiki/Nominatim). Defaults to "`nyc,tokyo,lima,london,shanghai`".
+ - `geocode_timeout`: timeout in seconds on api calls to [`Nominatim`](https://wiki.openstreetmap.org/wiki/Nominatim). Defaults to `10` seconds.
+
+### Simple Setup and Go
+
 #### Export DARK_SKY_API_KEY
 ```
 $ export DARK_SKY_API_KEY=<dark_ski_api_key>

--- a/config/sample.json
+++ b/config/sample.json
@@ -1,0 +1,3 @@
+{
+  "dark_sky_api_key": null
+}

--- a/config/systemd/weather_exporter.service
+++ b/config/systemd/weather_exporter.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Weather Exporter
+After=docker.service
+Requires=docker.service
+
+[Service]
+TimeoutStartSec=0
+Restart=always
+ExecStartPre=-/usr/bin/docker stop weather_exporter 
+ExecStartPre=-/usr/bin/docker rm weather_exporter
+ExecStart=/usr/bin/docker run --rm -p 9265:9265 --name weather_exporter celliott/weather_exporter
+
+[Install]
+WantedBy=multi-user.target

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 prometheus_client
 requests
-redis
 geopy
 backports.functools_lru_cache

--- a/src/weather_exporter/exporter.py
+++ b/src/weather_exporter/exporter.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# vim: tabstop=2 expandtab shiftwidth=2 softtabstop=2
 
 import requests, re, time, options
 from prometheus_client import start_http_server, Gauge
@@ -10,8 +11,8 @@ except ImportError:
 
 @lru_cache()
 def get_location(city):
-    location = Nominatim(timeout=options['geocode_timeout']).geocode(city)
-    return location
+  location = Nominatim(timeout=options['geocode_timeout']).geocode(city)
+  return location
 
 class WeatherExporter:
   def __init__(self,options):

--- a/src/weather_exporter/exporter.py
+++ b/src/weather_exporter/exporter.py
@@ -25,7 +25,8 @@ class WeatherExporter:
     try:
       response = requests.get(url).json()
       self.weather["{}".format(city)] = response
-    except: pass
+    except requests.exceptions.RequestException as e:
+      print e
 
   def to_underscore(self,str):
     return re.sub("([A-Z])", "_\\1", str).lower().lstrip("_")

--- a/src/weather_exporter/options.py
+++ b/src/weather_exporter/options.py
@@ -1,18 +1,92 @@
 #!/usr/bin/env python
-
+# vim: tabstop=2 expandtab shiftwidth=2 softtabstop=2
+import argparse
+import json
 import os
+import sys
+
+from urlparse import urlparse
+
+# DEFAULT_OPTIONS is a dictionary of string keys and values representing
+# defaultable commandline options.
+DEFAULT_OPTIONS = {
+  'dark_sky_api_uri': 'https://api.darksky.net/forecast',
+  'dark_sky_api_key' : '',
+  'scrape_interval': 600,
+  'endpoint_port': 9265,
+  'cities': 'nyc,tokyo,lima,london,shanghai',
+  'geocode_timeout': 10
+}
+
+# PARSER is an instance of argparse.ArgumentParser.
+PARSER = argparse.ArgumentParser(
+  description='Prometheus exporter for weather reports from https://darksky.net')
+
+# We add default options and enforce their type based on the default
+# values in DEFAULT_OPTIONS
+for option, default_val in DEFAULT_OPTIONS.iteritems():
+  option_type = type(default_val)
+  PARSER.add_argument("--{0}".format(option), type=option_type, help="default value: {0}".format(default_val))
+
+
+# config files are a special case with no default value, so we add the
+# commandline option manually
+PARSER.add_argument("--config", type=argparse.FileType('r'))
 
 def get():
-  dark_sky_api_uri = os.getenv('DARK_SKY_API_URI', 'https://api.darksky.net/forecast')
-  dark_sky_api_key = os.getenv('DARK_SKY_API_KEY')
-  if not dark_sky_api_key:
-    print "Unable to start; make sure to export your api key. See readme"
+  '''
+  Fetches options from file, environment, and commandline
+  commandline options are given priority, then environment, then file
+  ```
+  #> cat '{"foo": "c"}' > conf.json
+  #> weather_exporter --config=conf.json
+  // foo is 'c'
+
+  #> env FOO=b
+  #> weather_exporter --config=conf.json
+  // foo is 'b'
+
+  #> env FOO=b
+  #> weather_exporter --config=conf.json --foo=a
+  // foo is 'a'
+  ```
+  '''
+
+  # fetch out environment options
+  env_options = {k: os.getenv(k.upper()) for k in DEFAULT_OPTIONS.iterkeys()}
+  # clear env options with null values
+  env_options = {k: v for k, v in env_options.iteritems() if v}
+
+  # fetch out commandline options
+  cmdline_options = vars(PARSER.parse_args(sys.argv[1:]))
+  # clear commandline options with null values
+  cmdline_options = {k: v for k, v in cmdline_options.iteritems() if v}
+
+  # fetch file options
+  file_options = {}
+  if 'config' in cmdline_options.keys():
+    file_options = json.load(cmdline_options['config'])
+
+  # merge down defaults < file < env < commandline
+  final_options = DEFAULT_OPTIONS.copy()
+
+  final_options.update(file_options)
+  final_options.update(env_options)
+  final_options.update(cmdline_options)
+
+  if not final_options['dark_sky_api_key']:
+    print "ERROR; NO API KEY FOUND. make sure to set your api key. See readme"
     exit(1)
 
-  return {
-    'dark_sky_api_url': "{0}/{1}".format(dark_sky_api_uri,dark_sky_api_key),
-    'scrape_interval': int(os.getenv('SCRAPE_INTERVAL', 600)),
-    'endpoint_port': int(os.getenv('ENDPOINT_PORT', 9265)),
-    'cities': os.getenv('CITIES', "nyc,tokyo,vancouver,lima,london,shanghai"),
-    'geocode_timeout': int(os.getenv('GEOCODE_TIMEOUT', 10)),
-  }
+  dark_sky_uri = urlparse(final_options['dark_sky_api_uri'])
+  api_path = dark_sky_uri[2].strip()
+  if api_path[-1] != '/':
+    api_path += '/'
+
+  final_options['dark_sky_api_url'] = "{0}://{1}{2}{3}".format(
+                                        dark_sky_uri[0],
+                                        dark_sky_uri[1],
+                                        api_path,
+                                        final_options['dark_sky_api_key'])
+
+  return final_options


### PR DESCRIPTION
I did not want to configure `weather_exporter` with environment variables exclusively, so I overhauled how configuration is handled to enable the use of file-based and cmdline-based configuration. This is a pretty opinionated implementation, and I am definitely open to discussion on how this should be done.

I also removed `supervisord` from the docker image. I'm not sure why it is there.

I added a `systemd` config file I used to deploy `weather_exporter` on my home server. If it's not wanted I can drop it.